### PR TITLE
Deploy by branch instead of by sha

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -34,6 +34,8 @@ if [ "${BRANCH}" = "master" ]; then
     if [ ${#VERSION} -lt 6 ]; then
     
         echo "Creating GitHub release."
+        git config --global user.email "aaron0browne@gmail.com"
+        git config --global user.name "Aaron Browne"
         git tag -a "${VERSION}" -m "Release of version ${VERSION}"
         git push --tags
     
@@ -57,7 +59,7 @@ if [ "${BRANCH}" = "master" ]; then
 else
 
     echo "Creating new Elastic Beanstalk environment running new version."
-    AWSNAME="dmsa-${COMMIT_SHA1:0:8}"
+    AWSNAME="dmsa-${BRANCH}"
     aws --region=us-east-1 elasticbeanstalk create-environment \
         --application-name data-models-sqlalchemy \
         --environment-name "${AWSNAME}" \

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,6 @@
 machine:
-  pre:
-    - |
-      sudo curl -L -o /usr/bin/docker 'http://s3-external-1.amazonaws.com/circle-downloads/docker-1.6.2-circleci'
-      sudo chmod 0755 /usr/bin/docker
-      sudo start docker
+  services:
+    - docker
   python:
     version: 2.7.3
   environment:
@@ -38,7 +35,7 @@ deployment:
     branch: /.*/
     commands:
       - pip install awscli wheel twine
-      - |
-        sudo curl -L -o /usr/bin/jq 'http://stedolan.github.io/jq/download/linux64/jq'
+      - sudo curl -L -o /usr/bin/jq
+        'http://stedolan.github.io/jq/download/linux64/jq';
         sudo chmod 0755 /usr/bin/jq
       - ./ci/deploy.sh

--- a/dmsa/__init__.py
+++ b/dmsa/__init__.py
@@ -8,8 +8,8 @@ if sha:
 __version_info__ = {
     'major': 0,
     'minor': 4,
-    'micro': 4,
-    'releaselevel': 'final',
+    'micro': 5,
+    'releaselevel': 'alpha',
     'serial': serial,
     'sha': sha
 }


### PR DESCRIPTION
This should reduce the number of AWS environments that are created,
which should reduce the frequency with which we hit the 5 EIP limit.

Also, configure git username before trying to tag a release.

Also, use the newly-standard docker 1.6.2 service instead of manually
installing it.

Also, format the jq install more cleanly (to my taste).

Bump version to 0.4.5-alpha

Signed-off-by: Aaron Browne aaron0browne@gmail.com
