### PR TITLE
Align README and module generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ from dmsa.pedsnet.v2_0_0.models import Person, VisitPayer
 print VisitPayer.columns
 ```
 
-These models are dynamically generated at runtime from JSON endpoints provided by chop-dbhi/data-models-service, which reads data stored in chop-dbhi/data-models. It should be simple to add modules for any additional data models that become available, but the currently provided ones are:
+These models are dynamically generated at runtime from JSON endpoints provided by chop-dbhi/data-models-service, which reads data stored in chop-dbhi/data-models. Each data model version available on the service is included in a dynamically generated python module. At the time of writing, the following are available. Any added to the service will use the same naming conventions.
 
 - **OMOP V4** at `omop.v4_0_0.models`
 - **OMOP V5** at `omop.v5_0_0.models`
 - **PEDSnet V1** at `pedsnet.v1_0_0.models`
 - **PEDSnet V2** at `pedsnet.v2_0_0.models`
 - **i2b2 V1.7** at `i2b2.v1_7_0.models`
-- **i2b2 PEDSnet V2** at `i2b2.pedsnet.v2_0_0.models`
+- **i2b2 PEDSnet V2** at `i2b2_pedsnet.v2_0_0.models`
 - **PCORnet V1** at `pcornet.v1_0_0.models`
 - **PCORnet V2** at `pcornet.v2_0_0.models`
 - **PCORnet V3** at `pcornet.v3_0_0.models`

--- a/dmsa/__init__.py
+++ b/dmsa/__init__.py
@@ -8,8 +8,8 @@ if sha:
 __version_info__ = {
     'major': 0,
     'minor': 5,
-    'micro': 1,
-    'releaselevel': 'final',
+    'micro': 2,
+    'releaselevel': 'beta',
     'serial': serial,
     'sha': sha
 }
@@ -64,15 +64,20 @@ for model in MODELS:
 
         version_name = 'v' + version['name'].replace('.', '_')
         version_path = path + '.' + version_name
-
         version_module = imp.new_module(version_path)
         version_module.__file__ = '(dynamically constructed)'
         version_module.__dict__['__package__'] = 'dmsa'
         setattr(module, version_name, version_module)
+        sys.modules[version_path] = version_module
+
+        models_path = version_path + '.models'
+        models_module = imp.new_module(models_path)
+        models_module.__file__ = '(dynamically constructed)'
+        models_module.__dict__['__package__'] = 'dmsa'
+        setattr(version_module, 'models', models_module)
 
         code = version_module_code.format(name=model['name'],
                                           version=version['name'])
 
-        exec(code, version_module.__dict__)
-
-        sys.modules[version_path] = version_module
+        exec(code, models_module.__dict__)
+        sys.modules[models_path] = models_module


### PR DESCRIPTION
Edit module generation code to create <model>.<version>.models modules
(that last models module was not being created, before). Edit README to
make i2b2_pedsnet module accurate and point out that modules are
dynamically generated. Bump version to 0.5.2 beta

Signed-off-by: Aaron Browne aaron0browne@gmail.com
