### PR TITLE
Move deployment to CHOP AWS cloud

### DIFF
--- a/ci/after_create_env.eml.template
+++ b/ci/after_create_env.eml.template
@@ -1,0 +1,3 @@
+The DBHi TiU continuous integration and deployment workflow for <APP_NAME> has finished creating a new AWS ElasticBeanstalk environment named <AWS_ENV_NAME>. It should have been automatically tagged with the appropriate billing codes.
+
+The current health of the environment is <AWSHEALTH>.

--- a/ci/before_create_env.eml.template
+++ b/ci/before_create_env.eml.template
@@ -1,4 +1,3 @@
 The DBHi TiU continuous integration and deployment workflow for <APP_NAME> is attempting to create a new AWS ElasticBeanstalk environment named <AWS_ENV_NAME>. It should be automatically tagged with the appropriate billing codes.
 
-You will receive another email after the environment has been
-successfully created.
+You will receive another email after the environment has been successfully created.

--- a/ci/before_create_env.eml.template
+++ b/ci/before_create_env.eml.template
@@ -1,0 +1,4 @@
+The DBHi TiU continuous integration and deployment workflow for <APP_NAME> is attempting to create a new AWS ElasticBeanstalk environment named <AWS_ENV_NAME>. It should be automatically tagged with the appropriate billing codes.
+
+You will receive another email after the environment has been
+successfully created.

--- a/ci/success_status.json.template
+++ b/ci/success_status.json.template
@@ -1,6 +1,6 @@
 {
     "state": "success",
-    "target_url": "http://<AWSNAME>.elasticbeanstalk.com",
+    "target_url": "http://<AWS_ENV_NAME>.elasticbeanstalk.com",
     "description": "Deployed to AWS for review!",
     "context": "cd/awseb"
 }

--- a/circle.yml
+++ b/circle.yml
@@ -14,6 +14,8 @@ checkout:
     - ./ci/git-set-file-times.pl
 
 dependencies:
+  pre:
+    - pip install awscli wheel twine
   cache_directories:
     - "~/docker"
   post:
@@ -35,7 +37,6 @@ deployment:
   all:
     branch: /.*/
     commands:
-      - pip install awscli wheel twine
       - sudo curl -L -o /usr/bin/jq
         'http://stedolan.github.io/jq/download/linux64/jq';
         sudo chmod 0755 /usr/bin/jq

--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,7 @@ machine:
     BUILD_NUM: "${CIRCLE_BUILD_NUM}"
     COMMIT_SHA1: "${CIRCLE_SHA1}"
     BRANCH: "${CIRCLE_BRANCH}"
+    APP_NAME: "${CIRCLE_PROJECT_REPONAME}"
 
 checkout:
   post:

--- a/dmsa/__init__.py
+++ b/dmsa/__init__.py
@@ -8,7 +8,7 @@ if sha:
 __version_info__ = {
     'major': 0,
     'minor': 5,
-    'micro': 2,
+    'micro': 3,
     'releaselevel': 'beta',
     'serial': serial,
     'sha': sha

--- a/dmsa/__init__.py
+++ b/dmsa/__init__.py
@@ -8,8 +8,8 @@ if sha:
 __version_info__ = {
     'major': 0,
     'minor': 5,
-    'micro': 3,
-    'releaselevel': 'beta',
+    'micro': 4,
+    'releaselevel': 'alpha',
     'serial': serial,
     'sha': sha
 }


### PR DESCRIPTION
Mostly, the ci/deploy.sh script is updated to use more environment
variables, which are stored in the CircleCI project config. Also, and
attempt is made to add billing codes to new EBS environments and email
notifications about the creation of those resources. Changes have also
been made to the existing CircleCI project config environment variables
to point deployment at the CHOP AWS account.

Signed-off-by: Aaron Browne aaron0browne@gmail.com
