### PR TITLE
Add gunicorn server to Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN pip install -r /app/requirements.txt && pip install \
     cx-Oracle==5.1.3 \
     psycopg2==2.6 \
     MySQL-python==1.2.5 \
-    pyodbc==3.0.10
+    pyodbc==3.0.10 \
+    gunicorn==19.3.0
 
 # Copy app files.
 COPY . /app/
@@ -44,5 +45,4 @@ RUN pip install /app/
 # Set up run environment.
 EXPOSE 80
 WORKDIR /app
-ENTRYPOINT ["dmsa"]
-CMD ["start", "--host=0.0.0.0", "--port=80"]
+CMD ["gunicorn", "--bind=0.0.0.0:80", "--workers=4", "dmsa.service:app"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ dmsa.add_model_modules()
 # Now the data model modules are built and available for import.
 from dmsa.omop.v5_0_0.models import Base
 
-for tbl in Base.metadata.sorted_tables():
+for tbl in Base.metadata.sorted_tables:
     print tbl.name
 ```
 
@@ -73,37 +73,37 @@ docker pull dbhi/data-models-sqlalchemy
 Usage for DDL generation:
 
 ```sh
-docker run --rm dbhi/data-models-sqlalchemy ddl -h
+docker run --rm dbhi/data-models-sqlalchemy dmsa ddl -h
 ```
 
 Generate OMOP V5 creation DDL for Oracle:
 
 ```sh
-docker run --rm dbhi/data-models-sqlalchemy ddl omop 5.0.0 oracle
+docker run --rm dbhi/data-models-sqlalchemy dmsa ddl omop 5.0.0 oracle
 ```
 
 Generate OMOP V5 drop DDL for Oracle:
 
 ```sh
-docker run --rm dbhi/data-models-sqlalchemy ddl -d omop 5.0.0 oracle
+docker run --rm dbhi/data-models-sqlalchemy dmsa ddl -d omop 5.0.0 oracle
 ```
 
 Generate OMOP V5 data deletion DML for Oracle:
 
 ```sh
-docker run --rm dbhi/data-models-sqlalchemy ddl -x omop 5.0.0 oracle
+docker run --rm dbhi/data-models-sqlalchemy dmsa ddl -x omop 5.0.0 oracle
 ```
 
 Usage for ERD generation:
 
 ```sh
-docker run --rm dbhi/data-models-sqlalchemy erd -h
+docker run --rm dbhi/data-models-sqlalchemy dmsa erd -h
 ```
 
 Generate i2b2 PEDSnet V2 ERD (the image will land at `./erd/i2b2_pedsnet_2.0.0_erd.png`):
 
 ```sh
-docker run --rm -v $(pwd)/erd:/erd dbhi/data-models-sqlalchemy erd i2b2_pedsnet 2.0.0 /erd/i2b2_pedsnet_2.0.0_erd.png
+docker run --rm -v $(pwd)/erd:/erd dbhi/data-models-sqlalchemy dmsa erd i2b2_pedsnet 2.0.0 /erd/i2b2_pedsnet_2.0.0_erd.png
 ```
 
 The `graphviz` graphing package supports a number of other output formats, listed here (link pending), which are interpreted from the passed extension.
@@ -172,7 +172,7 @@ dmsa erd i2b2_pedsnet 2.0.0 ./erd/i2b2_pedsnet_2.0.0_erd.png
 
 ## Web Service
 
-The web service uses a simple Flask debug server for now. It exposes the following endpoints:
+The web service uses a [Gunicorn](http://gunicorn.org/) server in the Docker container and the Flask debug server locally. It exposes the following endpoints:
 
 - Creation DDL at `/<model>/<version>/ddl/<dialect>/`
 - Creation DDL for only `table`, `constraint`, or `index` elements at `/<model>/<version>/ddl/<dialect>/<elements>`
@@ -186,7 +186,7 @@ The web service uses a simple Flask debug server for now. It exposes the followi
 Usage:
 
 ```sh
-docker run  dbhi/data-models-sqlalchemy start -h
+docker run dbhi/data-models-sqlalchemy gunicorn -h
 ```
 
 Run:

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,8 @@ if sys.version_info < (2, 7) or sys.version_info > (3, 0):
 with open('README.md', 'r') as f:
     long_description = f.read()
 
-install_requires = [
-    'SQLAlchemy==1.0.5',
-    'ERAlchemy==0.0.28',
-    'Flask==0.10.1',
-    'docopt==0.6.2',
-    'requests==2.7.0'
-]
+with open('requirements.txt') as f:
+    install_requires = f.readlines()
 
 kwargs = {
     'name': 'dmsa',


### PR DESCRIPTION
The gunicorn server is installed in the Docker image and used to run the
service by default in the container. The local `serve` command still
uses the Flask debug server.

Fixes #18

Signed-off-by: Aaron Browne aaron0browne@gmail.com
