### PR TITLE
Increase size of version_history version and operation columns

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   services:
     - docker
   python:
-    version: 2.7.3
+    version: 2.7.11
   environment:
     # Just the repo name in a standard-ish variable.
     APP_NAME: "${CIRCLE_PROJECT_REPONAME}"

--- a/dmsa/ddl.py
+++ b/dmsa/ddl.py
@@ -109,11 +109,11 @@ def generate(model, model_version, dialect, tables=True, constraints=True,
         'version_history', MetaData(),
         Column('datetime', DateTime(), primary_key=True,
                server_default=text('CURRENT_TIMESTAMP')),
-        Column('operation', String(24)),
+        Column('operation', String(100)),
         Column('model', String(16)),
-        Column('model_version', String(16)),
-        Column('dms_version', String(16)),
-        Column('dmsa_version', String(16))
+        Column('model_version', String(50)),
+        Column('dms_version', String(50)),
+        Column('dmsa_version', String(50))
     )
 
     version_tbl_ddl = str(CreateTable(version_history).


### PR DESCRIPTION
The main offender is the dms_version column, which currently causes errors due to its narrowness.

The others are increased on the basis that this is a small table with few rows, and databases such as PostgreSQL don't pre-allocate storage for maximum column widths, anyway.
