### PR TITLE
Fix file locking and caching

### DIFF
--- a/dmsa/__init__.py
+++ b/dmsa/__init__.py
@@ -9,7 +9,7 @@ __version_info__ = {
     'major': 0,
     'minor': 6,
     'micro': 0,
-    'releaselevel': 'beta',
+    'releaselevel': 'final',
     'serial': serial,
     'sha': sha
 }


### PR DESCRIPTION
This is a fix to the previous PR, #54, which hasn't been deployed to production. 

I've tested this branch with terraform in the `test` workspace.

* Make file locking portable (work on Linux, etc in addition to Mac OS). Moral: always use Python errno system symbols, e.g. `errno.EWOULDBLOCK` when checking details of IOError exceptions.

* Fix caching so effects of webhook are picked up by all processes. This involved replacing `app.config['models']` and `app.config['service_version']` with function calls to check the cache. The service version is also now stored in the cache along with the models.

* Fix broken webhook handling; was triggering on issues instead of push. That was a careless holdover from debugging.

* Rename `models.py` to `cache.py` (and many variables within) because it really caches a generic object, not models per se. In particular, it is now used to cache a dict containing both models and service version.

Since it works and is not more horrendous than the previous accepted PR, it's probably best to draw the veil for now and merge this. I bumped the `releaselevel` to 'final'.